### PR TITLE
Add Wikidata id as id where available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,5 @@ gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
 gem 'table_unspanner', github: 'everypolitician/table_unspanner'
 gem 'vcr'
 gem 'webmock'
+gem 'wikidata-fetcher', '>= 0.19.1', github: 'everypolitician/wikidata-fetcher'
+gem 'wikisnakker', github: 'everypolitician/wikisnakker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,29 @@ GIT
       nokogiri
 
 GIT
+  remote: https://github.com/everypolitician/wikidata-fetcher.git
+  revision: 382c169fa212b8088058f16327722497ee72cf89
+  specs:
+    wikidata-fetcher (0.19.1)
+      colorize
+      diskcached
+      json
+      mediawiki_api
+      nokogiri
+      require_all
+      rest-client
+      scraperwiki
+      wikidata-client (~> 0.0.7)
+      wikisnakker
+
+GIT
+  remote: https://github.com/everypolitician/wikisnakker.git
+  revision: 502c9bd62a3c8a5e6671fc4744b4a5c7c5e618bc
+  specs:
+    wikisnakker (0.8.0)
+      yajl-ruby
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -38,13 +61,36 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
     coderay (1.1.0)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    diskcached (1.1.2)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    excon (0.54.0)
+    faraday (0.10.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     field_serializer (0.3.0)
     git (1.3.0)
     hashdiff (0.3.1)
+    hashie (3.4.6)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httpclient (2.6.0.1)
+    json (2.0.2)
+    mediawiki_api (0.7.0)
+      faraday (~> 0.9, >= 0.9.0)
+      faraday-cookie_jar (~> 0.0, >= 0.0.6)
+      faraday_middleware (~> 0.10, >= 0.10.0)
     method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minispec-metadata (2.0.0)
       minitest
@@ -55,6 +101,8 @@ GEM
       minispec-metadata (~> 2.0)
       minitest (>= 4.7.5)
       vcr (>= 2.9)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
@@ -69,6 +117,10 @@ GEM
     rainbow (2.1.0)
     rake (12.0.0)
     require_all (1.3.3)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -81,6 +133,9 @@ GEM
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.2)
     vcr (3.0.3)
     vcr-archive (0.3.0)
@@ -90,6 +145,12 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    wikidata-client (0.0.10)
+      excon (~> 0.40)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9)
+      hashie (~> 3.3)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -109,6 +170,8 @@ DEPENDENCIES
   table_unspanner!
   vcr
   webmock
+  wikidata-fetcher (>= 0.19.1)!
+  wikisnakker!
 
 RUBY VERSION
    ruby 2.3.3p222

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,6 +27,8 @@ class WikidataIds < Scraped::Response::Decorator
 end
 
 class WikipediaPage < Scraped::HTML
+  decorator WikidataIds
+
   field :current_composition do
     current_composition_rows.map do |tr|
       fragment tr => MemberRow
@@ -51,6 +53,10 @@ class WikipediaPage < Scraped::HTML
 end
 
 class MemberRow < Scraped::HTML
+  field :id do
+    tds[1].css('a/@wikidata').text
+  end
+
   field :name do
     tds[1].text.strip
   end
@@ -102,4 +108,3 @@ data = cur_page.current_composition.map  { |m| m.to_h.merge(term: 10) } +
 # puts data
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 ScraperWiki.save_sqlite(%i(name area term), data)
-


### PR DESCRIPTION
If we can finda a wikidata ID for the linked page, set it as the ID. This
will protect us slightly from wikipedia-level renamings.