### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -85,4 +85,3 @@ data = cur_page.current_composition.map  { |m| m.to_h.merge(term: 10) } +
 # puts data
 ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 ScraperWiki.save_sqlite(%i(name area term), data)
-

--- a/scraper.rb
+++ b/scraper.rb
@@ -83,6 +83,6 @@ data = cur_page.current_composition.map  { |m| m.to_h.merge(term: 10) } +
        prv_page.previous_composition.map { |m| m.to_h.merge(term: 8)  }
 
 # puts data
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 ScraperWiki.save_sqlite(%i(name area term), data)
 


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: everypolitician/everypolitician#593